### PR TITLE
Make entries appear immediately.

### DIFF
--- a/lib/components/letter_grid.dart
+++ b/lib/components/letter_grid.dart
@@ -59,9 +59,13 @@ class __LetterGridState extends State<LetterGrid> {
     widget.updateFocus(focusedSquare);
   }
 
+  /// If we're not at the end of the word, advance the cursor.
   void onAdvanceCursor() {
     setState(() {
-      focusedSquare = widget.currentClue.nextSquare(focusedSquare);
+      final nextSquare = widget.currentClue.nextSquare(focusedSquare);
+      if (nextSquare != null) {
+        focusedSquare = nextSquare;
+      }
     });
   }
 


### PR DESCRIPTION
Make TextEditingController part of the Cell State. Then when the user
updates the value, mark the cell NOT to take the server value when it is
rebuilt (which happens immediately to change the highlighting).

Also, fix a bug with cursor advancement - the entire app broke at the
end of words otherwise.