### PR TITLE
Improve rendering on large screens

### DIFF
--- a/lib/components/cell.dart
+++ b/lib/components/cell.dart
@@ -126,7 +126,7 @@ class _CellState extends State<Cell> {
       }
     };
 
-    final t = TextField(
+    final cellTextField = TextField(
       autocorrect: false,
       controller: controller,
       onChanged: userChanged,
@@ -147,7 +147,12 @@ class _CellState extends State<Cell> {
         border: Border.all(color: Colors.black),
         color: boxColour,
       ),
-      child: t,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          cellTextField,
+        ],
+      ),
     );
 
     if (widget.number != null) {

--- a/lib/components/letter_grid.dart
+++ b/lib/components/letter_grid.dart
@@ -8,6 +8,10 @@ import 'package:flutter/widgets.dart';
 import 'package:quiver/check.dart';
 import 'cell.dart';
 
+// You don't want the grid to get too big, because it's a square, and shouldn't
+// fill the screen.
+final maxGridWidth = 600.0;
+
 /// A user update to a cell in the grid.
 class GridUpdate {
   final int row;
@@ -70,19 +74,22 @@ class __LetterGridState extends State<LetterGrid> {
   }
 
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-            color: Colors.white30,
-            child: GridView.builder(
-              shrinkWrap: true,
-              physics: NeverScrollableScrollPhysics(),
-              itemCount: widget.width * widget.height,
-              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: widget.width),
-              itemBuilder: _cellBuilder,
-            )),
-      ],
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxGridWidth),
+      child: Column(
+        children: [
+          Container(
+              color: Colors.white30,
+              child: GridView.builder(
+                shrinkWrap: true,
+                physics: NeverScrollableScrollPhysics(),
+                itemCount: widget.width * widget.height,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: widget.width),
+                itemBuilder: _cellBuilder,
+              )),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Centre text vertically.
Set max width value on grid to stop it swallowing whole screen.